### PR TITLE
🏷️ Keeps tag if specified in FROM

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,20 @@ locker Dockerfile
 
 The test suite uses [Bats](https://github.com/bats-core/bats-core). To run the test suite:
 
-```
-npx bats test
-```
+1. Pull the used test images:
+    * `docker pull openjdk`
+    * `docker pull oracle/openjdk`
+    * `docker pull openjdk:8`
+1. Run the tests:
+
+    ```
+    npx bats test
+    ```
 
 ## To do
 
 * Use locally built images in tests to avoid having to pull them
 * Ignore images that don't exist locally
-* Keep tag when locking using the syntax `<image>:<tag>@<digest>`
 * Discard digest to allow relocking files
 * Recursive syntax to lock all supported files in a directory
 * Unlock flag to revert from digest to tag

--- a/locker
+++ b/locker
@@ -2,8 +2,9 @@
 
 function lock_image() {
 	IMAGE=$1
-	LOCKIMAGE=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE)
-	echo $LOCKIMAGE
+	NAME=$(echo $IMAGE | grep '^[^@]\+' -o)
+	DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE | grep '[^@]\+$' -o)
+	echo $NAME@$DIGEST
 }
 
 function lock_dockerfile() {

--- a/test/dockerfile.bats
+++ b/test/dockerfile.bats
@@ -21,7 +21,7 @@ DOCKERFILE=$BATS_TMPDIR/Dockerfile
   echo "FROM openjdk:8" > $DOCKERFILE
   run $LOCKER $DOCKERFILE
   [ "$status" -eq 0 ]
-  grep -q '^FROM openjdk@sha256:[a-z0-9]\{64\}$' $DOCKERFILE
+  grep -q '^FROM openjdk:8@sha256:[a-z0-9]\{64\}$' $DOCKERFILE
 }
 
 @test "Can lock Dockerfile FROM with AS" {


### PR DESCRIPTION
As per TODO, keep docker image tag if specified.

Also updates test documentation, as you need the test docker images locally for tests to pass.